### PR TITLE
Ajout d'un message d'erreur en cas d'erreur d'identification #45

### DIFF
--- a/pythounews/routes/routes.py
+++ b/pythounews/routes/routes.py
@@ -32,7 +32,7 @@ def connexion():
             login_user(utilisateur)
             return redirect("/")
         else:
-            flash("Les identifiants n'ont pas été reconnus", "alert")
+            flash("Les identifiants n'ont pas été reconnus", "danger")
             return render_template("pages/connexion.html")
     return render_template("pages/connexion.html")
 
@@ -61,7 +61,7 @@ def inscription():
             flash("Enregistrement effectué. Identifiez-vous maintenant", "success")
             return redirect("/")
         else:
-            flash("Les erreurs suivantes ont été rencontrées : " + ",".join(donnees), "alert")
+            flash("Les erreurs suivantes ont été rencontrées : " + ",".join(donnees), "danger")
             return render_template("pages/inscription.html")
     else:
         return render_template("pages/inscription.html")

--- a/pythounews/routes/routes.py
+++ b/pythounews/routes/routes.py
@@ -23,7 +23,7 @@ def connexion():
         return redirect("/")
     # Si on est en POST, cela veut dire que le formulaire a été envoyé
     if request.method == "POST":
-        utilisateur = User.identification(
+        utilisateur=User.identification(
             login=request.form.get("login", None),
             motdepasse=request.form.get("motdepasse", None)
         )
@@ -33,7 +33,7 @@ def connexion():
             return redirect("/")
         else:
             flash("Les identifiants n'ont pas été reconnus", "alert")
-
+            return render_template("pages/connexion.html")
     return render_template("pages/connexion.html")
 
     login.login_view = 'connexion'

--- a/pythounews/templates/pages/connexion.html
+++ b/pythounews/templates/pages/connexion.html
@@ -1,7 +1,7 @@
 {% include "partials/header.html" %}
 
 <h1>Connexion</h1>
-<form class="form" method="POST" action="{{url_for("connexion")}}">
+<form class="form" method="POST" action="{{url_for('connexion')}}">
 
   <div class="form-group row">
     <label for="login" class="col-sm-2 col-form-label">Pseudo</label>


### PR DESCRIPTION
Juste des petites modifications pour éviter de faire planter le site à chaque fois qu'un utilisateur utilise le mauvais mdp ou le mauvais identifiant.