### PR TITLE
Revert "reprise de modification du message d'erreur promo issue #71"

### DIFF
--- a/pythounews/models/utilisateurs.py
+++ b/pythounews/models/utilisateurs.py
@@ -41,10 +41,6 @@ class User(UserMixin, db.Model):
         :param email: Email de l'utilisateur-rice
         :param nom: Nom de l'utilisateur-rice
         :param motdepasse: Mot de passe de l'utilisateur-rice (Minimum 6 caractères)
-        :param promo: Année de promotion de l'utilisateur-rice
-        :param spe: Spécialité de l'utilisateur-rice
-        :param bio: Courte biographie de l'utilisateur-rice
-
 
         """
         erreurs = []
@@ -56,9 +52,6 @@ class User(UserMixin, db.Model):
             erreurs.append("Le nom fourni est vide")
         if not motdepasse or len(motdepasse) < 6:
             erreurs.append("Le mot de passe fourni est vide ou trop court")
-        if not promo or not type(promo)==int :
-            erreurs.append("La promo fournie est vide ou ne correspond pas à une année")
-
 
         # On vérifie que personne n'a utilisé cet email ou ce login
         uniques = User.query.filter(


### PR DESCRIPTION
J'ai testé de me réinscrire sur le site, et malgré le fait que la promo soit une année, le message `Les erreurs suivantes ont été rencontrées : La promo fournie est vide ou ne correspond pas à une année` s'affiche, et il est impossible de s'inscrire.