### PR TITLE
Affichage des publications dans la page profil #138

### DIFF
--- a/pythounews/models/publications.py
+++ b/pythounews/models/publications.py
@@ -41,20 +41,20 @@ class Publication(db.Model):
         if len(erreurs) > 0:
             return False, erreurs
 
-            # on récupére avec requests la page html du lien entré par l'utilisateur
-            page_html = requests.get(lien)
-            #  avec BS on insére dans la variable soup le contenu de la page html en utilisant le parser de python
-            soup = BeautifulSoup(page_html.text, 'html.parser')
-            # on crée une variable qui récupère dans notre page html les balises <meta/> qui ont un attribut name
-            # avec une valeur "description". (.find avec BeautifulSoup)
-            balise_meta_desc = soup.find("meta", attrs={"name": u"description"})
-            # on crée une variable description_url qui récupère la valeur de l'attr content
-            if balise_meta_desc:
-                description_url = balise_meta_desc.get("content")
-            else:
-                description_url = "Aucune description n'est disponible"
-            balise_titre = soup.title
-            titre_url = balise_titre.get_text()
+        # on récupére avec requests la page html du lien entré par l'utilisateur
+        page_html = requests.get(lien)
+        #  avec BS on insére dans la variable soup le contenu de la page html en utilisant le parser de python
+        soup = BeautifulSoup(page_html.text, 'html.parser')
+        # on crée une variable qui récupère dans notre page html les balises <meta/> qui ont un attribut name
+        # avec une valeur "description". (.find avec BeautifulSoup)
+        balise_meta_desc = soup.find("meta", attrs={"name": u"description"})
+        # on crée une variable description_url qui récupère la valeur de l'attr content
+        if balise_meta_desc:
+            description_url = balise_meta_desc.get("content")
+        else:
+            description_url = "Aucune description n'est disponible"
+        balise_titre = soup.title
+        titre_url = balise_titre.get_text()
 
         date = datetime.date.today()
         publication = Publication(
@@ -99,4 +99,3 @@ class Publication(db.Model):
                  "description_url": description_url, "auteur": auteur})
 
         return liste_publications
-

--- a/pythounews/routes/routes.py
+++ b/pythounews/routes/routes.py
@@ -101,11 +101,18 @@ def deconnexion():
 @app.route("/profil")
 @login_required
 def profil():
-    """ Route permettant l'affichage du profil de l'utilisateur
+    """ Route permettant l'affichage du profil de l'utilisateur et l'affichage de ses publications.
 
     :return: page html profil de l'utilisateur
     """
-    return render_template("pages/profil.html")
+    #On récupère l'id de l'utilisateur connecté
+    id_utilisateur = current_user.user_id
+    #On ne sélectionne parmi les publications que celles dotn l'id de l'auteur correspond à l'id de l'utilisateur, et on les classes par date.
+    publications = Publication.query.filter(Publication.publi_user_id==id_utilisateur).order_by(Publication.publication_date.desc()).paginate(page=1)
+    #On récupère l'ensemble des informations concernant les publications que l'on va afficher
+    publications = Publication.afficher_publications(publications)
+
+    return render_template("pages/profil.html", publications=publications)
 
 
 @app.route("/modif_profil/<int:user_id>", methods=["POST", "GET"])
@@ -139,13 +146,15 @@ def modif_profil(user_id) :
 @app.route("/afficher_profil_utilisateur/<int:user_id>")
 @login_required
 def afficher_profil_utilisateur(user_id) :
-    """ Route permettant d'afficher le profil d'un utilisateur lorsque l'on est connecté
+    """ Route permettant d'afficher le profil d'un utilisateur lorsque l'on est connecté, et les publications attachées à cet utilisateur.
 
     :return: page html profil d'un utilisateur
     """
-
+    #On récupère l'id de l'utilisateur
     utilisateur = User.query.get(user_id)
+    #On ne sélectionne parmi les publications que celles dotn l'id de l'auteur correspond à l'id de l'utilisateur, et on les classes par date.
     publications = Publication.query.filter(Publication.publi_user_id==utilisateur.user_id).order_by(Publication.publication_date.desc()).paginate(page=1)
+    #On récupère l'ensemble des informations concernant les publications que l'on va afficher
     publications = Publication.afficher_publications(publications)
 
     return render_template("pages/profil_utilisateur.html", utilisateur=utilisateur, publications=publications)

--- a/pythounews/routes/routes.py
+++ b/pythounews/routes/routes.py
@@ -145,8 +145,10 @@ def afficher_profil_utilisateur(user_id) :
     """
 
     utilisateur = User.query.get(user_id)
+    publications = Publication.query.filter(Publication.publi_user_id==utilisateur.user_id).order_by(Publication.publication_date.desc()).paginate(page=1)
+    publications = Publication.afficher_publications(publications)
 
-    return render_template("pages/profil_utilisateur.html", utilisateur=utilisateur)
+    return render_template("pages/profil_utilisateur.html", utilisateur=utilisateur, publications=publications)
 
 
 @app.route("/recherche")

--- a/pythounews/templates/pages/profil.html
+++ b/pythounews/templates/pages/profil.html
@@ -45,6 +45,26 @@
 <div class="div text-center">
     <a type="submit" class="btn btn-success" href="{{url_for('modif_profil', user_id=current_user.user_id)}}">Modifier le profil</a>
 </div>
+<div>
+<h2 style="text-align:center">Vos publications</h2>
+    <div class="row d-flex justify-content-around">
+            {% if publications%}
+              {% for item in publications%}
+        <div class="col-4 bg-light border border-white">
+              <p class="align-middle">Publiée le {{item["date"]}} <!-- Date du jour --> par <a href="{{url_for ('afficher_profil_utilisateur', user_id = item["auteur"].user_id)}}">{{item["auteur"].user_login}}</a> <br/>
+                {{item["titre"]}}<br/> <!-- Titre donné par l'utilisateur -->
+                {{item["texte"]}}<br/> <!-- commentaire donné par l'utilisateur -->
+                <a href="{{item['lien']}}">{{item["titre_url"]}}</a> <br/> <!-- item 2 : url item 4 titre de l'url -->
+                {{item["description_url"]}} <!-- description automatique -->
+              </p>
+                </div>
+
+              {% endfor %}
+              {%else%}
+              <p style="text-align:center">Vous n'avez rien publié (pour le moment).</p>
+            {% endif %}
+          </div>
+          </div>
 </body>
 </html>
 

--- a/pythounews/templates/pages/profil_utilisateur.html
+++ b/pythounews/templates/pages/profil_utilisateur.html
@@ -28,7 +28,26 @@
             <div class="col-3">{{utilisateur.user_email}}</div>
         </div>
     </div>
-  </body>
+
+<div>
+<h2 style="text-align:center">Toutes les publications de {{utilisateur.user_nom}}</h2>
+</div>
+    <div class="row d-flex justify-content-around">
+            {% if publications%}
+              {% for item in publications%}
+        <div class="col-4 bg-light border border-white">
+              <p class="align-middle">Publiée le {{item["date"]}} <!-- Date du jour --> par <a href="{{url_for ('afficher_profil_utilisateur', user_id = item["auteur"].user_id)}}">{{item["auteur"].user_login}}</a> <br/>
+                {{item["titre"]}}<br/> <!-- Titre donné par l'utilisateur -->
+                {{item["texte"]}}<br/> <!-- commentaire donné par l'utilisateur -->
+                <a href="{{item['lien']}}">{{item["titre_url"]}}</a> <br/> <!-- item 2 : url item 4 titre de l'url -->
+                {{item["description_url"]}} <!-- description automatique -->
+              </p>
+                </div>
+
+              {% endfor %}
+            {% endif %}
+          </div>
+      </body>
 </html>
 
 {% include "partials/footer.html" %}

--- a/pythounews/templates/pages/profil_utilisateur.html
+++ b/pythounews/templates/pages/profil_utilisateur.html
@@ -31,7 +31,6 @@
 
 <div>
 <h2 style="text-align:center">Toutes les publications de {{utilisateur.user_nom}}</h2>
-</div>
     <div class="row d-flex justify-content-around">
             {% if publications%}
               {% for item in publications%}
@@ -46,6 +45,7 @@
 
               {% endfor %}
             {% endif %}
+          </div>
           </div>
       </body>
 </html>


### PR DESCRIPTION
Conformément à #138 , les publications s'affichent actuellement sur les pages profils de chaque utilisateur, ainsi que sur la page profil de l'utilisateur connecté. 

Aussi, en voulant tester la page `Publier`, j'ai remarqué qu'elle ne fonctionnait plus, à cause de l'indentation dans la méthode statique `creer_publication`. J'en ai donc profité pour réindenter la méthode :) 