### PR TITLE
Modification de l'affichage des résultats dans la page recherche

### DIFF
--- a/pythounews/templates/pages/recherche.html
+++ b/pythounews/templates/pages/recherche.html
@@ -5,19 +5,22 @@
     <h1>Résultat(s) de votre recherche</h1>
     {% if resultats %}
         <p>{{resultats.total}} résultat(s) répond(ent) à votre recherche :</p>
-        <ul>
+          <ul>
             {% for publication in resultats.items %}
-                <li>{{publication.publication_nom}}<br/>
-                  <p>
+            <li>
+            <div class="row d-flex col-12 bg-light border border-white">
+              <p>
+                <span style="font-weight:bold">{{publication.publication_nom}}</span><br/>
                     Publiée le {{publication.publication_date}} <!-- Date du jour -->
                     {{publication.publication_titre }}<br/> <!-- Titre donné par l'utilisateur -->
                     {{publication.publication_texte}}<br/> <!-- commentaire donné par l'utilisateur -->
                     <a href="{{publication.publication_lien}}">{{publication.publication_lien}}</a><br/>
                     {{publication.publication_description_url}}<br/><!--description récupérée via BeautifulSoup -->
                   </p>
-                </li>
+                </div>
+              </ui>
             {% endfor %}
-        </ul>
+          </ol>
     <nav aria-label="research-pagination">
       <ul class="pagination">
         {% for page in resultats.iter_pages() %}


### PR DESCRIPTION
Conformément à #140 , j'ai modifié l'affichage des résultats. 
J'ai mis en gras les titres des publications, histoire que les différents résultats soient plus visible pour l'utilisateur. 

(PS : Je me suis trompé dans le numéro de la branche, issue-139 aurait du s'appeler issue-140 ^^)