### PR TITLE
Supprimer l'affichage de None pour les publications #161

### DIFF
--- a/pythounews/templates/pages/accueil.html
+++ b/pythounews/templates/pages/accueil.html
@@ -50,7 +50,7 @@
     </div>
 
     <div class="row">
-        <div class="col-12"><a href="{{url_for('rss')}}" class="btn btn-success btn-sm btn-block">Plus de
+        <div class="col-12"><a href="{{url_for('afficherrss')}}" class="btn btn-success btn-sm btn-block">Plus de
             flux par ici</a></div>
     </div>
 

--- a/pythounews/templates/pages/afficherpublis.html
+++ b/pythounews/templates/pages/afficherpublis.html
@@ -21,8 +21,15 @@
             <br/>
             {{item["titre"]}}<br/> <!-- Titre donné par l'utilisateur -->
             {{item["texte"]}}<br/> <!-- commentaire donné par l'utilisateur -->
+            {% if item["titre_url"] == None %}
+            <a href="{{item['lien']}}">{{item["lien"]}}</a> <br/>
+            {% else %}
             <a href="{{item['lien']}}">{{item["titre_url"]}}</a> <br/> <!-- item 2 : url item 4 titre de l'url -->
+            {% endif %}
+            {% if item["description_url"] == None %}
+            {% else %}
             {{item["description_url"]}} <!-- description automatique -->
+            {% endif %}
         </p>
     </div>
 


### PR DESCRIPTION
Un `None` s'affichait quand la publication n'avait pas d'information sur le lien, maintenant on n'affiche plus rien. 

J'ai aussi corrigé un bug que j'avais laissé au moment de changer le nom de certaines fonctions. 

